### PR TITLE
Add Brigade namespace config and use it

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
                         "brig-path": {
                             "type": "string",
                             "description": "File path to a brig binary"
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace where Brigade is configured in your cluster"
                         }
                     }
                 }

--- a/src/brigade/brigade.ts
+++ b/src/brigade/brigade.ts
@@ -7,15 +7,17 @@ import { ProjectSummary, BuildSummary } from './brigade.objectmodel';
 import { parseTable } from './parsers';
 import { Age } from '../utils/age';
 
-const logChannel = vscode.window.createOutputChannel("Duffle");
+const logChannel = vscode.window.createOutputChannel("Brigade");
 
 async function invokeObj<T>(sh: shell.Shell, command: string, args: string, opts: shell.ExecOpts, fn: (stdout: string) => T): Promise<Errorable<T>> {
     const bin = config.brigPath() || 'brig';
-    const cmd = `${bin} ${command} ${args}`;
+    const brigadeNamespace = config.getConfiguredNamespace() || 'default';
+    const nsarg = `--namespace ${brigadeNamespace}`;
+    const cmd = `${bin} ${command} ${args} ${nsarg}`;
     logChannel.appendLine(`$ ${cmd}`);
     return await sh.execObj<T>(
         cmd,
-        `duffle ${command}`,
+        `brig ${command}`,
         opts,
         andLog(fn)
     );

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -13,3 +13,7 @@ export function brigPath(): string | undefined {
 export function toolPath(tool: string): string | undefined {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[`${tool}-path`];
 }
+
+export function getConfiguredNamespace(): string | undefined {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['namespace'];
+}

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -149,7 +149,7 @@ function unquotedPath(path: string): string {
 export function shellEnvironment(baseEnvironment: any): any {
     const env = Object.assign({}, baseEnvironment);
     const pathVariable = pathVariableName(env);
-    for (const tool of ['duffle']) {
+    for (const tool of ['brig']) {
         const toolPath = config.toolPath(tool);
         if (toolPath) {
             const toolDirectory = path.dirname(toolPath);


### PR DESCRIPTION
This PR adds a config for the Brigade namespace and adds it as a flag for `brig`.
Notice that the default namespace for `brig` can also be configured through the `BRIGADE_NAMESPACE` environment variable - not sure which is the better approach here (or even reuse the `kubectl` context).

It also updates the name of the output channel to `Brigade`.