### PR TITLE
Add command to open web dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
                         "namespace": {
                             "type": "string",
                             "description": "Namespace where Brigade is configured in your cluster"
+                        },
+                        "port": {
+                            "type": "integer",
+                            "description": "Local port for the web dashboard. Default 8081"
+                        },
+                        "open-dashboard": {
+                            "type": "boolean",
+                            "description": "Open the dashboard in the browser. Default true"
                         }
                     }
                 }
@@ -62,6 +70,11 @@
                     "light": "images/light/refresh.svg",
                     "dark": "images/dark/refresh.svg"
                 }
+            },
+            {
+                "command": "brigade.openWebDashboard",
+                "category": "Brigade",
+                "title": "Open Web Dashboard"
             }
         ],
         "viewsContainers": {

--- a/src/brigade/brigade.ts
+++ b/src/brigade/brigade.ts
@@ -8,6 +8,7 @@ import { parseTable } from './parsers';
 import { Age } from '../utils/age';
 
 const logChannel = vscode.window.createOutputChannel("Brigade");
+const terminalName = "Brigade";
 
 async function invokeObj<T>(sh: shell.Shell, command: string, args: string, opts: shell.ExecOpts, fn: (stdout: string) => T): Promise<Errorable<T>> {
     const bin = config.brigPath() || 'brig';
@@ -82,4 +83,28 @@ export function rerun(sh: shell.Shell, buildId: string): Promise<Errorable<Proje
         return { buildId: match[1], workerId: match[2] };
     }
     return invokeObj(sh, 'rerun', `${buildId}`, {}, parse);
+}
+
+export async function openWebDashboard(): Promise<void> {
+    const bin = config.brigPath() || 'brig';
+    const brigadeNamespace = config.getConfiguredNamespace() || 'default';
+    const port = config.getConfiguredPort() || 8081;
+    const open = config.openDashboard();
+    const args = `--namespace ${brigadeNamespace} --port ${port} --open-dashboard=${open}`;
+    const cmd = `${bin} dashboard ${args}`;
+
+    const terminal = ensureTerminal();
+    terminal.sendText(cmd);
+    terminal.show();
+}
+
+function ensureTerminal(): vscode.Terminal {
+    const terminals = vscode.window.terminals;
+    for (const term of terminals) {
+        if (term.name === terminalName) {
+            return term;
+        }
+    }
+
+    return vscode.window.createTerminal(terminalName);
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -17,3 +17,16 @@ export function toolPath(tool: string): string | undefined {
 export function getConfiguredNamespace(): string | undefined {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['namespace'];
 }
+
+export function getConfiguredPort(): number | undefined {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['port'];
+}
+
+export function openDashboard(): boolean {
+    const cfg: boolean = vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['open-dashboard'];
+    if (cfg == undefined) {
+        return true;
+    }
+
+    return cfg;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { BrigadeResourceDocumentProvider } from './documents/brigaderesource.doc
 import { hasResourceURI } from './projectexplorer/node.hasresourceuri';
 import { onCommandRunProject } from './commands/runproject';
 import { onCommandRerunBuild } from './commands/rerunbuild';
+import { openWebDashboard } from './brigade/brigade';
 
 let currentExtensionContext: vscode.ExtensionContext | null = null;
 
@@ -21,6 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand("brigade.runProject", onCommandRunProject),
         vscode.commands.registerCommand("brigade.rerunBuild", onCommandRerunBuild),
         vscode.commands.registerCommand("brigade.refreshProjectExplorer", onCommandRefreshProjectExplorer),
+        vscode.commands.registerCommand("brigade.openWebDashboard", openWebDashboard),
 
         // Documents
         vscode.workspace.registerTextDocumentContentProvider(BrigadeResourceDocumentProvider.scheme(), new BrigadeResourceDocumentProvider()),


### PR DESCRIPTION
This PR adds a command to open the web dashboard, by calling `brig dashboard --port {config} --open-dashboard {config}`.